### PR TITLE
Fixed issues with keybinds being unable to be pressed due to open GUI (Fixes #40)

### DIFF
--- a/src/main/java/dmillerw/menu/gui/GuiRadialMenu.java
+++ b/src/main/java/dmillerw/menu/gui/GuiRadialMenu.java
@@ -56,10 +56,9 @@ public class GuiRadialMenu extends GuiScreen {
                                 return;
                             } else {
                                 if (!disabled && button == 0) {
-                                    if (menuItem.clickAction.onClicked()) {
-                                        deactivate();
-                                        return;
-                                    }
+                                    deactivate();
+                                    menuItem.clickAction.onClicked();
+                                    return;
                                 }
                             }
                         } else {


### PR DESCRIPTION
I've been having issues using this mod to open other GUIs, and since I saw this mod on GitHub, I figured I'd check out the mod's source code for myself. Turns out, the reason why most keybinds don't actually work in the menu is because the menu is still open when forge attempts to press a key or open a new GUI. In order to fix this, I made the menu close before the menu attempts to press a key. Since the method that presses a key always returns true, this should have no effect on the code. Enjoy! :)